### PR TITLE
removed cudnn8 dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
+FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
 WORKDIR /root
 RUN apt-get update -y && apt-get install -y python3-pip
 COPY infer.py jfk.flac ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ huggingface_hub>=0.13
 tokenizers>=0.13,<1
 onnxruntime>=1.14,<2 
 pyannote-audio>=3.1.1
-torch>=2.1.1,<2.4.0
-torchaudio>=2.1.2,<2.4.0
+torch>=2.1.1
+torchaudio>=2.1.2
 tqdm


### PR DESCRIPTION
- Relaxing torch requirements since ctranslate2 now [supports](https://github.com/OpenNMT/CTranslate2/releases/tag/v4.5.0) cudnn9 